### PR TITLE
Use babel-plugin-inline-json-import to ship the current package.json

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -11,5 +11,6 @@ module.exports = {
     ],
     plugins: [
         "@babel/plugin-proposal-class-properties",
+        "inline-json-import"
     ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1528,6 +1528,15 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-inline-json-import": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-inline-json-import/-/babel-plugin-inline-json-import-0.3.2.tgz",
+      "integrity": "sha512-QNNJx08KjmMT25Cw7rAPQ6dlREDPiZGDyApHL8KQ9vrQHbrr4PTi7W8g1tMMZPz0jEMd39nx/eH7xjnDNxq5sA==",
+      "dev": true,
+      "requires": {
+        "decache": "^4.5.1"
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
@@ -1746,6 +1755,12 @@
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
       }
+    },
+    "callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+      "dev": true
     },
     "callsites": {
       "version": "3.1.0",
@@ -2022,6 +2037,15 @@
       "dev": true,
       "requires": {
         "ms": "2.0.0"
+      }
+    },
+    "decache": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/decache/-/decache-4.5.1.tgz",
+      "integrity": "sha512-5J37nATc6FmOTLbcsr9qx7Nm28qQyg1SK4xyEHqM0IBkNhWFp0Sm+vKoWYHD8wq+OUEb9jLyaKFfzzd1A9hcoA==",
+      "dev": true,
+      "requires": {
+        "callsite": "^1.0.0"
       }
     },
     "decamelize": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@babel/preset-env": "^7.6.0",
     "@babel/preset-typescript": "^7.6.0",
     "babel-jest": "^24.9.0",
+    "babel-plugin-inline-json-import": "^0.3.2",
     "browserslist-config-nextcloud": "0.0.1",
     "jest": "^24.9.0",
     "typescript": "^3.6.3"


### PR DESCRIPTION
This makes sure the package.json is included in the transpiled files at build time so we do not depend on the package.json that is produced by installing the package as a dependency.

