### PR TITLE
Add naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,14 @@ emit('a', {
 unsubscribe('a', h)
 unsubscribe('b', h)
 ```
+
+## Naming convention
+To stay consistent, we encourage you to use the following syntax when declaring events
+
+`app-id:action:verb`
+
+### Examples:
+- nextcloud:unified-search:close
+- contacts:contact:delete
+- calendar:event:create
+- forms:answer:update

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ unsubscribe('b', h)
 ## Naming convention
 To stay consistent, we encourage you to use the following syntax when declaring events
 
-`app-id:action:verb`
+`app-id:object:verb`
 
 ### Examples:
 - nextcloud:unified-search:close

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ To stay consistent, we encourage you to use the following syntax when declaring 
 `app-id:object:verb`
 
 ### Examples:
-- nextcloud:unified-search:close
-- contacts:contact:delete
-- calendar:event:create
-- forms:answer:update
+- nextcloud:unified-search:closed
+- files:file:uploading
+- files:file:uploaded
+- contacts:contact:deleted
+- calendar:event:created
+- forms:answer:updated


### PR DESCRIPTION
## Naming convention
To stay consistent, we encourage you to use the following syntax when declaring events

`app-id:action:verb`

### Examples:
- nextcloud:unified-search:close
- contacts:contact:delete
- calendar:event:create
- forms:answer:update
