### PR TITLE
Run node tests on github actions

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,36 @@
+name: Node
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - stable*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-versions: [12.x, 14.x, 16.x]
+
+    name: node${{ matrix.node-versions }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up node ${{ matrix.node-versions }}
+        uses: actions/setup-node@v1
+        with:
+          node-versions: ${{ matrix.node-versions }}
+
+      - name: Install dependencies & build
+        run: |
+          npm ci
+          npm run build --if-present
+
+      - name: Run tests
+        run: npm run test
+
+      - name: Build docs
+        run: npm run build:doc

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "babel ./lib --out-dir dist --extensions '.ts,.tsx' --source-maps && tsc --emitDeclarationOnly",
-    "build:doc": "typedoc --excludeNotExported --mode file --out dist/doc lib/index.ts && touch dist/doc/.nojekyll",
+    "build:doc": "typedoc --out dist/doc lib/index.ts && touch dist/doc/.nojekyll",
     "check-types": "tsc",
     "dev": "babel ./lib --out-dir dist --extensions '.ts,.tsx' --watch",
     "test": "jest",


### PR DESCRIPTION
Travis seems to no longer build since 5 months ago, so with this we at least have CI running for the build and tests.

I preserved the travis config for now as it still contains the automatic documentation build which we'd need to migrate as well at some point.