### PR TITLE
fix: Make package importable for `type="module"` projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,21 +2,23 @@
   "name": "@nextcloud/event-bus",
   "version": "3.0.2",
   "description": "A simple event bus to communicate between Nextcloud components.",
-  "main": "dist/index.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/index.cjs",
   "types": "dist/index.d.ts",
   "exports": {
-    "import": "./dist/index.esm.js",
-    "require": "./dist/index.js"
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
   },
   "files": [
     "dist/"
   ],
   "scripts": {
-    "build": "rollup --config rollup.config.js",
+    "build": "rollup --config rollup.config.mjs",
     "build:doc": "typedoc --out dist/doc lib/index.ts && touch dist/doc/.nojekyll",
     "check-types": "tsc --noEmit",
-    "dev": "rollup --config rollup.config.js --watch",
+    "dev": "rollup --config rollup.config.mjs --watch",
     "test": "jest",
     "test:watch": "jest --watchAll"
   },

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,7 +1,7 @@
 import typescript from '@rollup/plugin-typescript'
 import replace from '@rollup/plugin-replace'
 
-import pkg from './package.json'
+import pkg from './package.json' assert { type: 'json' }
 
 const external = [/semver/]
 
@@ -25,7 +25,7 @@ export default [
     ],
     output: [
       {
-        dir: 'dist',
+        file: 'dist/index.cjs',
         format: 'cjs',
         sourcemap: true,
       },
@@ -37,7 +37,7 @@ export default [
     plugins: [typescript(), replacePlugin],
     output: [
       {
-        file: 'dist/index.esm.js',
+        file: 'dist/index.mjs',
         format: 'esm',
         sourcemap: true,
       },

--- a/test/ProxyBus.test.js
+++ b/test/ProxyBus.test.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-const { SimpleBus, ProxyBus } = require('../dist')
+const { SimpleBus, ProxyBus } = require('..')
 
 describe('ProxyBus', () => {
     test('proxy invalid bus', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-const { emit, subscribe, unsubscribe } = require('../dist/index')
+const { emit, subscribe, unsubscribe } = require('..')
 
 test('readme example', () => {
     const h = jest.fn()


### PR DESCRIPTION
Explicitly set the type of the dist files by changing the file extension to `mjs` or `cjs` respectively.

Without this fix, you get following error when importing from this package:
```
SyntaxError: Named export 'emit' not found. The requested module '@nextcloud/event-bus' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from '@nextcloud/event-bus';
const { subscribe: r, emit: a, unsubscribe: c } = pkg;
```

This happens because the type is not set, so node assumes commonjs and will interpret every `.js` file as commonjs file regardless of the `exports` section.